### PR TITLE
fix(VIP-974): Aikido - Dockerfile and GHA hardening

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,36 +8,36 @@ on:
 
 permissions:
   id-token: write
-  contents: write
+  contents: read
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Validate composer
-        uses: php-actions/composer@v6
+        uses: php-actions/composer@8a65f0d3c6a1d17ca4800491a40b5756a4c164f3 # v6
         with:
           command: validate
           php_version: '8.3'
 
       - name: Cache dependencies
         id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: vendor
           key: ${{ runner.os }}-php-composer-sync-${{ hashFiles('**/composer.lock') }}-
 
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
-        uses: php-actions/composer@v6
+        uses: php-actions/composer@8a65f0d3c6a1d17ca4800491a40b5756a4c164f3 # v6
         with:
           php_version: '8.3'
 
       - name: Set default php version
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: '8.3'
 
@@ -51,10 +51,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Validate composer
-        uses: php-actions/composer@v6
+        uses: php-actions/composer@8a65f0d3c6a1d17ca4800491a40b5756a4c164f3 # v6
         with:
           command: validate
           php_version: '8.3'
@@ -64,18 +64,18 @@ jobs:
 
       - name: Cache dependencies
         id: composer-cache
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: vendor
           key: ${{ runner.os }}-php-composer-no-dev-${{ hashFiles('**/composer.lock') }}-
 
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
-        uses: php-actions/composer@v6
+        uses: php-actions/composer@8a65f0d3c6a1d17ca4800491a40b5756a4c164f3 # v6
         with:
           php_version: '8.3'
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           role-to-assume: ${{ vars.AWS_BLOCKCHYP_WOO_GITHUB_DEPLOY_ROLE }}
           aws-region: us-west-2

--- a/docker/wordpress_xdebug/Dockerfile
+++ b/docker/wordpress_xdebug/Dockerfile
@@ -1,3 +1,4 @@
-FROM wordpress
+FROM wordpress:6.9.4-php8.3-apache
 RUN pecl install xdebug \
   && docker-php-ext-enable xdebug
+USER www-data


### PR DESCRIPTION
## Summary

Addresses all four Aikido security alerts for blockchyp-woocommerce (VIP-974).

### Dockerfile — `docker/wordpress_xdebug/Dockerfile`

| Change | Before | After |
|--------|--------|-------|
| Base image | `FROM wordpress` (unpinned `:latest`) | `FROM wordpress:6.9.4-php8.3-apache` |
| Run user | root | `USER www-data` |

### GitHub Actions — `.github/workflows/build.yml`

| Change | Before | After |
|--------|--------|-------|
| `contents` permission | `write` | `read` |
| [actions/checkout](https://github.com/actions/checkout/releases/tag/v4.2.2) | `@v2` | [`11bd7190`](https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683) (v4.2.2) |
| [php-actions/composer](https://github.com/php-actions/composer/releases/tag/v6) | `@v6` | [`8a65f0d3`](https://github.com/php-actions/composer/commit/8a65f0d3c6a1d17ca4800491a40b5756a4c164f3) (v6) |
| [actions/cache](https://github.com/actions/cache/releases/tag/v3) | `@v3` | [`6f8efc29`](https://github.com/actions/cache/commit/6f8efc29b200d32929f49075959781ed54ec270c) (v3) |
| [shivammathur/setup-php](https://github.com/shivammathur/setup-php/releases/tag/v2) | `@v2` | [`accd6127`](https://github.com/shivammathur/setup-php/commit/accd6127cb78bee3e8082180cb391013d204ef9f) (v2) |
| [aws-actions/configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4.0.2) | `@v4` | [`e3dd6a42`](https://github.com/aws-actions/configure-aws-credentials/commit/e3dd6a429d7300a6a4c196c26e071d42e0343502) (v4.0.2) |

## Aikido Alerts Resolved
- Issue group 14645200: Unpinned base Docker image
- Issue group 14645201: Docker container runs as root
- Issue group 26111222: Overly broad GHA permissions (`contents: write`)
- Issue group 14645202: 3rd party GHA actions not pinned

## Test plan
- [ ] CI passes on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)